### PR TITLE
handle rejection in cache promise to avoid orphan chain

### DIFF
--- a/src/deck/_utils/texture-data.ts
+++ b/src/deck/_utils/texture-data.ts
@@ -149,6 +149,8 @@ function loadCached<T>(loadFunction: LoadFunction<T>): CachedLoadFunction<T> {
     cache.set(cacheKey, dataPromise);
     dataPromise.then(data => {
       cache.set(cacheKey, data);
+    }).catch(() => {
+      /* empty */
     });
     return dataPromise;
   };


### PR DESCRIPTION
The cache then()-chain creates a new orphaned Promise that becomes quite noisy when the data promise throws. As the rejection propagates through the detached chain with no handler, the runtime raises an UnhandledPromiseRejection error.

This PR adds a catch()-handler to avoid this.

One might also consider cleaning up failed data promises:

```ts
    dataPromise.then(data => {
      cache.set(cacheKey, data);
    }).catch(() => {
      cache.delete(cacheKey);
    });
```